### PR TITLE
unique pool identifiers

### DIFF
--- a/pathos/multiprocessing.py
+++ b/pathos/multiprocessing.py
@@ -71,6 +71,7 @@ __all__ = ['ProcessPool','_ProcessPool']
 #FIXME: probably not good enough... should store each instance with a uid
 __STATE = _ProcessPool__STATE = {}
 
+from datetime import datetime
 from pathos.abstract_launcher import AbstractWorkerPool
 from pathos.helpers.mp_helper import starargs as star
 from pathos.helpers import cpu_count, freeze_support, ProcessPool as Pool
@@ -103,7 +104,7 @@ Mapper that leverages python's multiprocessing.
         self.__nodes = kwds.get('ncpus', cpu_count())
 
         # Create an identifier for the pool
-        self._id = 'pool'
+        self._id = 'pool_' + str(datetime.now())
 
         # Create a new server if one isn't already initialized
         self._serve()


### PR DESCRIPTION
unique pool identifier every time ProcessPool constructor is called, using datetime.

The code below no longer causes an error, I presume this is more desirable behaviour?
Otherwise please do let me know if this is not a good thing.

```
import pathos.multiprocessing as multiprocessing

def print_hello():
    print('hello')

def main():
    run_once()
    run_once()

def run_once():
    pool = multiprocessing.ProcessingPool(1)
    pool.pipe(print_hello)
    pool.close()
    pool.join()
    pool.terminate()

if __name__ == '__main__':
    main()
```
  