### PR TITLE
pass the chunksize parameter to multiprocessing.Pool().map()

### DIFF
--- a/pathos/multiprocessing.py
+++ b/pathos/multiprocessing.py
@@ -134,22 +134,22 @@ Mapper that leverages python's multiprocessing.
     def map(self, f, *args, **kwds):
         AbstractWorkerPool._AbstractWorkerPool__map(self, f, *args, **kwds)
         _pool = self._serve()
-        return _pool.map(star(f), zip(*args)) # chunksize
+        return _pool.map(star(f), zip(*args), **kwds)
     map.__doc__ = AbstractWorkerPool.map.__doc__
     def imap(self, f, *args, **kwds):
         AbstractWorkerPool._AbstractWorkerPool__imap(self, f, *args, **kwds)
         _pool = self._serve()
-        return _pool.imap(star(f), zip(*args)) # chunksize
+        return _pool.imap(star(f), zip(*args), **kwds)
     imap.__doc__ = AbstractWorkerPool.imap.__doc__
     def uimap(self, f, *args, **kwds):
         AbstractWorkerPool._AbstractWorkerPool__imap(self, f, *args, **kwds)
         _pool = self._serve()
-        return _pool.imap_unordered(star(f), zip(*args)) # chunksize
+        return _pool.imap_unordered(star(f), zip(*args), **kwds)
     uimap.__doc__ = AbstractWorkerPool.uimap.__doc__
     def amap(self, f, *args, **kwds): # register a callback ?
         AbstractWorkerPool._AbstractWorkerPool__map(self, f, *args, **kwds)
         _pool = self._serve()
-        return _pool.map_async(star(f), zip(*args)) # chunksize
+        return _pool.map_async(star(f), zip(*args), **kwds)
     amap.__doc__ = AbstractWorkerPool.amap.__doc__
     ########################################################################
     # PIPES


### PR DESCRIPTION
Hi, 

I saw your comment here: https://stackoverflow.com/a/55615340/6804110, and I see you didn't  put in the chunksize  parameter by design.
But I think passing the kwds directly to multiprocessing.Pool().map() might solve the problem, because the only keyword argument left is chunksize. And by using kwds, the users can choose whether they want to pass the chunksize parameter.
I can also change it to `map(self, f, *args, chunksize=None, **kwds)` if you prefer this way.

Does it make sense to you? Will it cause any side effect?