### PR TITLE
Allow passing kwds to ProcessPool

### DIFF
--- a/pathos/multiprocessing.py
+++ b/pathos/multiprocessing.py
@@ -96,27 +96,27 @@ Mapper that leverages python's multiprocessing.
             kwds['ncpus'] = kwds.pop('nodes')
         elif arglen:
             kwds['ncpus'] = args[0]
-        self.__nodes = kwds.get('ncpus', cpu_count())
+        self.__nodes = kwds.pop('ncpus', cpu_count())
 
         # Create an identifier for the pool
-        self._id = kwds.get('id', None) #'pool'
+        self._id = kwds.pop('id', None) #'pool'
         if self._id is None:
             self._id = self.__nodes
 
         # Create a new server if one isn't already initialized
-        self._serve()
+        self._serve(**kwds)
         return
     if AbstractWorkerPool.__init__.__doc__: __init__.__doc__ = AbstractWorkerPool.__init__.__doc__ + __init__.__doc__
    #def __exit__(self, *args):
    #    self._clear()
    #    return
-    def _serve(self, nodes=None): #XXX: should be STATE method; use id
+    def _serve(self, nodes=None, **kwds): #XXX: should be STATE method; use id
         """Create a new server if one isn't already initialized"""
         if nodes is None: nodes = self.__nodes
         _pool = __STATE.get(self._id, None)
         if not _pool or nodes != _pool.__nodes:
             self._clear()
-            _pool = Pool(nodes)
+            _pool = Pool(nodes, **kwds)
             _pool.__nodes = nodes
             __STATE[self._id] = _pool
         return _pool

--- a/pathos/multiprocessing.py
+++ b/pathos/multiprocessing.py
@@ -103,27 +103,30 @@ Mapper that leverages python's multiprocessing.
         if self._id is None:
             self._id = self.__nodes
 
+        self._kwds = kwds
+
         # Create a new server if one isn't already initialized
-        self._serve(**kwds)
+        self._serve()
         return
     if AbstractWorkerPool.__init__.__doc__: __init__.__doc__ = AbstractWorkerPool.__init__.__doc__ + __init__.__doc__
    #def __exit__(self, *args):
    #    self._clear()
    #    return
-    def _serve(self, nodes=None, **kwds): #XXX: should be STATE method; use id
+    def _serve(self, nodes=None): #XXX: should be STATE method; use id
         """Create a new server if one isn't already initialized"""
         if nodes is None: nodes = self.__nodes
         _pool = __STATE.get(self._id, None)
-        if not _pool or nodes != _pool.__nodes:
+        if not _pool or nodes != _pool.__nodes or self._kwds != _pool._kwds:
             self._clear()
-            _pool = Pool(nodes, **kwds)
+            _pool = Pool(nodes, **self._kwds)
             _pool.__nodes = nodes
+            _pool._kwds = self._kwds
             __STATE[self._id] = _pool
         return _pool
     def _clear(self): #XXX: should be STATE method; use id
         """Remove server with matching state"""
         _pool = __STATE.get(self._id, None)
-        if _pool and self.__nodes == _pool.__nodes:
+        if _pool and self.__nodes == _pool.__nodes and self._kwds == _pool._kwds:
             _pool.close()
             _pool.join()
             __STATE.pop(self._id, None)

--- a/pathos/multiprocessing.py
+++ b/pathos/multiprocessing.py
@@ -180,14 +180,15 @@ Mapper that leverages python's multiprocessing.
     def restart(self, force=False):
         "restart a closed pool"
         _pool = __STATE.get(self._id, None)
-        if _pool and self.__nodes == _pool.__nodes:
+        if _pool and self.__nodes == _pool.__nodes and self._kwds == _pool._kwds:
             RUN = 0
             if not force:
                 assert _pool._state != RUN
             # essentially, 'clear' and 'serve'
             self._clear()
-            _pool = Pool(self.__nodes)
+            _pool = Pool(self.__nodes, **self._kwds)
             _pool.__nodes = self.__nodes
+            _pool._kwds = self._kwds
             __STATE[self._id] = _pool
         return _pool
     def close(self):

--- a/pathos/tests/test_mp.py
+++ b/pathos/tests/test_mp.py
@@ -37,6 +37,36 @@ def test_mp():
     assert result == _result
     assert end - start > 0.5
 
+def test_tp():
+    # instantiate and configure the worker pool
+    from pathos.pools import ThreadPool
+    pool = ThreadPool(nodes=4)
+
+    _result = list(map(pow, [1,2,3,4], [5,6,7,8]))
+
+    # do a blocking map on the chosen function
+    result = pool.map(pow, [1,2,3,4], [5,6,7,8])
+    assert result == _result
+
+    # do a non-blocking map, then extract the result from the iterator
+    result_iter = pool.imap(pow, [1,2,3,4], [5,6,7,8])
+    result = list(result_iter)
+    assert result == _result
+
+    # do an asynchronous map, then get the results
+    result_queue = pool.amap(pow, [1,2,3,4], [5,6,7,8])
+    result = result_queue.get()
+    assert result == _result
+
+    # test ThreadPool keyword argument propagation
+    pool.clear()
+    pool = ThreadPool(nodes=4, initializer=lambda: time.sleep(0.6))
+    start = time.monotonic()
+    result = pool.map(pow, [1,2,3,4], [5,6,7,8])
+    end = time.monotonic()
+    assert result == _result
+    assert end - start > 0.5
+
 
 def test_chunksize():
     # instantiate and configure the worker pool
@@ -125,5 +155,6 @@ if __name__ == '__main__':
     from pathos.helpers import freeze_support, shutdown
     freeze_support()
     test_mp()
+    test_tp()
     test_chunksize()
     shutdown()

--- a/pathos/tests/test_mp.py
+++ b/pathos/tests/test_mp.py
@@ -5,13 +5,14 @@
 # Copyright (c) 2016-2022 The Uncertainty Quantification Foundation.
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/pathos/blob/master/LICENSE
+import time
 
 def test_mp():
     # instantiate and configure the worker pool
     from pathos.pools import ProcessPool
     pool = ProcessPool(nodes=4)
 
-    _result = list(map(pow, [1,2,3,4], [5,6,7,8])) 
+    _result = list(map(pow, [1,2,3,4], [5,6,7,8]))
 
     # do a blocking map on the chosen function
     result = pool.map(pow, [1,2,3,4], [5,6,7,8])
@@ -26,6 +27,15 @@ def test_mp():
     result_queue = pool.amap(pow, [1,2,3,4], [5,6,7,8])
     result = result_queue.get()
     assert result == _result
+
+    # test ProcessPool keyword argument propagation
+    pool.clear()
+    pool = ProcessPool(nodes=4, initializer=lambda: time.sleep(0.6))
+    start = time.monotonic()
+    result = pool.map(pow, [1,2,3,4], [5,6,7,8])
+    end = time.monotonic()
+    assert result == _result
+    assert end - start > 0.5
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi 👋 

I would like to propagate `maxtasksperchild` keyword, but for this I had to switch from `pathos` to `multiprocess` ref https://github.com/ddelange/mapply/pull/29.

This however decreases stability/cleanup of workers, so rather allow a pathos user to propagate it :)