### PR TITLE
define html_theme as rtd workaround

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,6 +137,8 @@ if not on_rtd:
    #import sphinx_rtd_theme
    #html_theme = 'sphinx_rtd_theme'
    #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+else:
+    html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary
define html_theme as rtd workaround

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.