### PR TITLE
formal support for python 3.12, initial for 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ matrix:
         - python: '3.11'
           env:
 
-        - python: '3.12-dev'
+        - python: '3.12'
+          env:
+
+        - python: '3.13-dev'
           env:
             - DILL="master"
 
@@ -24,17 +27,17 @@ matrix:
           env:
             - MULTIPROCESS="true"
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.12
+        - python: 'pypy3.9-7.3.9' # at 7.3.13
           env:
             - MULTIPROCESS="true"
 
-        - python: 'pypy3.10-7.3.12'
+        - python: 'pypy3.10-7.3.13'
           env:
             - MULTIPROCESS="true"
 
     allow_failures:
-        - python: '3.12-dev'
-        - python: 'pypy3.10-7.3.12' # CI missing
+        - python: '3.13-dev'
+        - python: 'pypy3.10-7.3.13' # CI missing
     fast_finish: true
 
 cache:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_kwds = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py310
     py311
     py312
+    py313
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
add formal support for python 3.12, initial support for python 3.13

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.