### PR TITLE
drop formal support for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 
 matrix:
     include:
-        - python: '3.8'
-          env:
-
         - python: '3.9'
           env:
             - COVERAGE="true"
@@ -27,10 +24,6 @@ matrix:
             - DILL="master"
             - PPFT="master"
             - MULTIPROCESS="master"
-
-        - python: 'pypy3.8-7.3.9' # at 7.3.11
-          env:
-            - MULTIPROCESS="true"
 
         - python: 'pypy3.9-7.3.9' # at 7.3.16
           env:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Requirements
 ------------
 ``pathos`` requires:
 
-* ``python`` (or ``pypy``), **>=3.8**
+* ``python`` (or ``pypy``), **>=3.9**
 * ``setuptools``, **>=42**
 * ``pox``, **>=0.3.6**
 * ``dill``, **>=0.4.0**

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@
 import os
 import sys
 # drop support for older python
-if sys.version_info < (3, 8):
-    unsupported = 'Versions of Python before 3.8 are not supported'
+if sys.version_info < (3, 9):
+    unsupported = 'Versions of Python before 3.9 are not supported'
     raise ValueError(unsupported)
 
 # get distribution meta info
@@ -55,14 +55,13 @@ setup_kwds = dict(
         'Source Code':'https://github.com/uqfoundation/pathos',
         'Bug Tracker':'https://github.com/uqfoundation/pathos/issues',
     },
-    python_requires = '>=3.8',
+    python_requires = '>=3.9',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -94,8 +93,8 @@ ppft_version = 'ppft>=1.7.7'
 dill_version = 'dill>=0.4.0'
 pox_version = 'pox>=0.3.6'
 mp_version = 'multiprocess>=0.70.18'
-pyina_version = 'pyina>=0.3.0'
-mystic_version = 'mystic>=0.4.3'
+pyina_version = 'pyina>=0.3.1'
+mystic_version = 'mystic>=0.4.4'
 # add dependencies
 depend = [ppft_version, dill_version, pox_version, mp_version]
 extras = {'examples': [mystic_version, pyina_version]}

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,15 @@
 skip_missing_interpreters=
     True
 envlist =
-    py38
     py39
     py310
     py311
     py312
     py313
     py314
-    pypy38
     pypy39
     pypy310
+    pypy311
 
 [testenv]
 deps =


### PR DESCRIPTION
## Summary
drop formal support for python 3.8
Closes: #297 
