### PR TITLE
Fix bare except clauses across connection.py, core.py, abstract_launcher.py, __main__.py

### DIFF
--- a/pathos/__main__.py
+++ b/pathos/__main__.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     sys.exit(0)
   try:
     myinp = sys.argv[1]
-  except: myinp = None
+  except IndexError: myinp = None
   if myinp:
     rhost = myinp #XXX: should test rhost validity here... (how ?)
   else: pass # use default
@@ -84,7 +84,7 @@ if __name__ == '__main__':
   # get server to run from user
   try:
     myinp = sys.argv[2]
-  except: myinp = None
+  except IndexError: myinp = None
   if myinp:
     server = myinp #XXX: should test validity here... (filename)
   else: pass # use default
@@ -101,7 +101,7 @@ if __name__ == '__main__':
   # get remote port to run server on from user
   try:
     myinp = sys.argv[3]
-  except: myinp = None
+  except IndexError: myinp = None
   if myinp:
     if tunnel: # tunnel doesn't take more inputs
       msg = "port '%s' not valid for 'tunnel'" % myinp
@@ -117,7 +117,7 @@ if __name__ == '__main__':
   # get remote profile (this should go away soon)
   try:
     myinp = sys.argv[4]
-  except: myinp = None
+  except IndexError: myinp = None
   if myinp:
     rprof = myinp #XXX: should test validity here... (filename)
     profiles = {rhost:rprof}

--- a/pathos/abstract_launcher.py
+++ b/pathos/abstract_launcher.py
@@ -175,7 +175,7 @@ Other class members:
               raise TypeError("%s() takes at most %s arguments (%s given)" % (f.__name__(), str(vars), str(arglen)))
             elif arglen < (vars - defs):
               raise TypeError("%s() takes at least %s arguments (%s given)" % (f.__name__(), str(vars - defs), str(arglen)))
-        except:
+        except Exception:
             pass
         return
     def _serve(self, *args, **kwds):

--- a/pathos/connection.py
+++ b/pathos/connection.py
@@ -124,7 +124,7 @@ Inputs:
                 p = Popen(self.message, shell=True,
                           stdin=self.stdin, stdout=PIPE,
                           stderr=STDOUT, close_fds=True)
-            except:
+            except Exception:
                 raise PipeException('failure to pipe: %s' % self.message)
             self._pid = p.pid #get fileobject pid
             self._stdout = p.stdout #save fileobject
@@ -132,7 +132,7 @@ Inputs:
             try:
                 p = Popen(self.message, shell=True,
                           stdin=self.stdin, stdout=PIPE)
-            except:
+            except Exception:
                 raise PipeException('failure to pipe: %s' % self.message)
             self._stdout = p.stdout
             self._pid = 0 #XXX: MMM --> or -1 ?

--- a/pathos/core.py
+++ b/pathos/core.py
@@ -262,7 +262,7 @@ Args:
   launcher.launch()
   try:
     rport = int(launcher.response())
-  except:
+  except Exception:
     from pathos.secure import TunnelException
     raise TunnelException("failure to pick remote port")
   # return remote port number


### PR DESCRIPTION
Several bare `except:` clauses across the codebase catch `BaseException`, which includes `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. This can prevent clean shutdown and mask bugs.

## Changes

**`pathos/connection.py`** (lines 127, 135)
Replace bare `except:` with `except Exception:` in `launch()`. The handler re-raises as `PipeException` — there is no reason to catch interpreter signals.

**`pathos/core.py`** (line 265)
Replace bare `except:` with `except Exception:` in `randomport()`. The handler re-raises as `TunnelException`.

**`pathos/abstract_launcher.py`** (line 178)
Replace bare `except: pass` with `except Exception: pass` in `_launcher_proxy()`. Silently swallowing `KeyboardInterrupt` or `SystemExit` here would prevent clean process exit.

**`pathos/__main__.py`** (lines 78, 87, 104, 120)
Replace bare `except:` with `except IndexError:` for `sys.argv` access. The only exception that can be raised by `sys.argv[N]` for a missing argument is `IndexError` — catching everything is overly broad.